### PR TITLE
Rename zang

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 Zang Inc.
+Copyright 2020 Avaya Cloud Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in the

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,13 @@ zang-go
 ==========
 
 This golang package is an open source tool built to simplify interaction with
-the `Zang <http://www.zang.io>`_ telephony platform. Avaya OneCloud™️ CPaaS  makes adding voice
+the `Avaya CPaaS <http://www.zang.io>`_ telephony platform. Avaya OneCloud™️ CPaaS  makes adding voice
 and SMS to applications fun and easy.
 
-For more information about Zang, please visit:
+For more information about Avaya CPaaS, please visit:
 `Avaya OneCloud™️ CPaaS  <https://www.zang.io/products/cloud>`_
 
-To read the official documentation, please visit: `Zang Docs <http://docs.zang.io/aspx/docs>`_.
+To read the official documentation, please visit: `Avaya CPaaS Docs <http://docs.zang.io/aspx/docs>`_.
 
 
 Installation
@@ -39,7 +39,7 @@ In order to authorize against Avaya OneCloud™️ CPaaS  services you'll have t
 REST
 ----
 
-See the `Zang REST API documentation <http://docs.zang.io/aspx/rest>`_
+See the `Avaya CPaaS REST API documentation <http://docs.zang.io/aspx/rest>`_
 for more information.
 
 **NOTE: ** Please go through tests for specific endpoint to see the example
@@ -82,7 +82,7 @@ For more information please visit the `Zang InboundXML documentation
 
   ixml, err := New(Response{Say: &Say{
     Voice: "female",
-    Value: "Welcome to Zang!",
+    Value: "Welcome to Avaya CPaaS!",
     Loop:  3,
   }})
 
@@ -96,7 +96,7 @@ will render
 
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <Response>
-        <Say loop="3" voice="female" language="en">Welcome to Zang!</Say>
+        <Say loop="3" voice="female" language="en">Welcome to Avaya CPaaS!</Say>
     </Response>
 
 .. code-block:: xml

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@ zang-go
 ==========
 
 This golang package is an open source tool built to simplify interaction with
-the `Zang <http://www.zang.io>`_ telephony platform. Zang Cloud makes adding voice
+the `Zang <http://www.zang.io>`_ telephony platform. Avaya OneCloud™️ CPaaS  makes adding voice
 and SMS to applications fun and easy.
 
 For more information about Zang, please visit:
-`Zang Cloud <https://www.zang.io/products/cloud>`_
+`Avaya OneCloud™️ CPaaS  <https://www.zang.io/products/cloud>`_
 
 To read the official documentation, please visit: `Zang Docs <http://docs.zang.io/aspx/docs>`_.
 
@@ -27,7 +27,7 @@ Usage
 
 Authorization
 ----
-In order to authorize against Zang Cloud services you'll have to define authentication credentials. 
+In order to authorize against Avaya OneCloud™️ CPaaS  services you'll have to define authentication credentials.
 
 .. code-block:: bash
 

--- a/accounts.go
+++ b/accounts.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/applications.go
+++ b/applications.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/applications_test.go
+++ b/applications_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/calls.go
+++ b/calls.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/calls_test.go
+++ b/calls_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/carrier.go
+++ b/carrier.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/carrier_test.go
+++ b/carrier_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/common.go
+++ b/common.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/conferences.go
+++ b/conferences.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/conferences_test.go
+++ b/conferences_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/constants.go
+++ b/constants.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/fraud.go
+++ b/fraud.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/fraud_test.go
+++ b/fraud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/conference.go
+++ b/inboundxml/conference.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/conference_test.go
+++ b/inboundxml/conference_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/dial.go
+++ b/inboundxml/dial.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/dial_test.go
+++ b/inboundxml/dial_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/gather.go
+++ b/inboundxml/gather.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/gather_test.go
+++ b/inboundxml/gather_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/hangup.go
+++ b/inboundxml/hangup.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/hangup_test.go
+++ b/inboundxml/hangup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/inboundxml.go
+++ b/inboundxml/inboundxml.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/inboundxml_test.go
+++ b/inboundxml/inboundxml_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/invalid.go
+++ b/inboundxml/invalid.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/mms.go
+++ b/inboundxml/mms.go
@@ -4,9 +4,9 @@
 
 package inboundxml
 
-// Zang allows MMS messages to be sent during a call using the <Mms> element.
+// Avaya CPaaS allows MMS messages to be sent during a call using the <Mms> element.
 // The MMS receiver (to attribute) must be a valid phone number.
-// The sender (from attribute) must be one of your registered Zang numbers.
+// The sender (from attribute) must be one of your registered Avaya CPaaS numbers.
 // The text of the message should be placed inside the element and can not be longer than 160 characters.
 
 // The action attribute can be used to direct the MMS to a new InboundXML document for processing.

--- a/inboundxml/mms.go
+++ b/inboundxml/mms.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/mms_test.go
+++ b/inboundxml/mms_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/number.go
+++ b/inboundxml/number.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/number_test.go
+++ b/inboundxml/number_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/pause.go
+++ b/inboundxml/pause.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/pause_test.go
+++ b/inboundxml/pause_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/ping.go
+++ b/inboundxml/ping.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/ping_test.go
+++ b/inboundxml/ping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/play.go
+++ b/inboundxml/play.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/play_last_recording.go
+++ b/inboundxml/play_last_recording.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/play_last_recording_test.go
+++ b/inboundxml/play_last_recording_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/play_test.go
+++ b/inboundxml/play_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/record.go
+++ b/inboundxml/record.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/record_test.go
+++ b/inboundxml/record_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/redirect.go
+++ b/inboundxml/redirect.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/redirect_test.go
+++ b/inboundxml/redirect_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/reject.go
+++ b/inboundxml/reject.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/reject_test.go
+++ b/inboundxml/reject_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/response.go
+++ b/inboundxml/response.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/say.go
+++ b/inboundxml/say.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/say_test.go
+++ b/inboundxml/say_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/sip.go
+++ b/inboundxml/sip.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/sip_test.go
+++ b/inboundxml/sip_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/sms.go
+++ b/inboundxml/sms.go
@@ -4,9 +4,9 @@
 
 package inboundxml
 
-// Zang allows SMS messages to be sent during a call using the <Sms> element.
+// Avaya CPaaS allows SMS messages to be sent during a call using the <Sms> element.
 // The SMS receiver (to attribute) must be a valid phone number.
-// The sender (from attribute) must be one of your registered Zang numbers.
+// The sender (from attribute) must be one of your registered Avaya CPaaS numbers.
 // The text of the message should be placed inside the element and can not be longer than 160 characters.
 
 // The action attribute can be used to direct the SMS to a new InboundXML document for processing.

--- a/inboundxml/sms.go
+++ b/inboundxml/sms.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/sms_test.go
+++ b/inboundxml/sms_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/inboundxml/sms_test.go
+++ b/inboundxml/sms_test.go
@@ -15,7 +15,7 @@ func TestSmsElement(t *testing.T) {
 		ixml, err := New(Response{Sms: &Sms{
 			From:  "(phone_number)",
 			To:    "(phone_number)",
-			Value: "Test message sent from Zang!",
+			Value: "Test message sent from Avaya CPaaS!",
 		}})
 		So(ixml, ShouldNotBeNil)
 		So(err, ShouldBeNil)

--- a/mms.go
+++ b/mms.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/mms_test.go
+++ b/mms_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/notifications.go
+++ b/notifications.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/numbers.go
+++ b/numbers.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/recordings.go
+++ b/recordings.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/recordings_test.go
+++ b/recordings_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/request.go
+++ b/request.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip.go
+++ b/sip.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip_credentials.go
+++ b/sip_credentials.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip_credentials_test.go
+++ b/sip_credentials_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip_ipacl.go
+++ b/sip_ipacl.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip_ipacl_test.go
+++ b/sip_ipacl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip_mappings.go
+++ b/sip_mappings.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip_mappings_test.go
+++ b/sip_mappings_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sip_test.go
+++ b/sip_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sms.go
+++ b/sms.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/sms_test.go
+++ b/sms_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/transcriptions.go
+++ b/transcriptions.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/transcriptions_test.go
+++ b/transcriptions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/usage.go
+++ b/usage.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/usage_test.go
+++ b/usage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/validation.go
+++ b/validation.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Zang Authors. All rights reserved.
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Rename 
Zang = Avaya CPaaS
Zang Cloud = Avaya OneCloud™️ CPaaS
Copyright and Trademark should be Avaya Cloud Inc.