### PR TITLE
Support for Refer verb in GO SDK & upgrade to Go 1.16 version 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/zang-cloud/zang-go
+
+go 1.16
+
+require (
+	github.com/jbussdieker/golibxml v0.0.0-20190103165431-90c340ae5026
+	github.com/krolaw/xsd v0.0.0-20190108013600-03ca754cf4c5
+	github.com/smartystreets/goconvey v1.7.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jbussdieker/golibxml v0.0.0-20190103165431-90c340ae5026 h1:TPogeYeHConkXMdEe2yTo2ADgIJwt5R0a7x2opRyyXY=
+github.com/jbussdieker/golibxml v0.0.0-20190103165431-90c340ae5026/go.mod h1:i2oUhX2OxuK3iMtUaGux93pSm+5ntPgTt5RWmC9JAIU=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/krolaw/xsd v0.0.0-20190108013600-03ca754cf4c5 h1:HDbSPhZXQZ8TJIz1/76RflmPCA0GS4mTOrZO9vy+NOg=
+github.com/krolaw/xsd v0.0.0-20190108013600-03ca754cf4c5/go.mod h1:lsisaKHqT9AeR4TEF7sKMUftSixpucFr1ndlUgPNCtk=
+github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
+github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
+github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
+github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/inboundxml/inboundxml_test.go
+++ b/inboundxml/inboundxml_test.go
@@ -41,6 +41,6 @@ func TestInboundXMLResponse(t *testing.T) {
 		ixml, err := New(Response{Invalid: &Invalid{}})
 		So(ixml, ShouldBeNil)
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldContainSubstring, "Document validation error")
+		So(err.Error(), ShouldContainSubstring, "Element 'Invalid': This element is not expected.")
 	})
 }

--- a/inboundxml/refer.go
+++ b/inboundxml/refer.go
@@ -1,0 +1,15 @@
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package inboundxml
+
+type Refer struct {
+	Value          string `xml:",chardata"`
+	Action         string `xml:"action,attr,omitempty"`
+	Method         string `xml:"method,attr,omitempty"`
+	Timeout        int    `xml:"timeout,attr,omitempty"`
+	CallbackUrl    string `xml:"callbackUrl,attr,omitempty"`
+	CallbackMethod string `xml:"callbackMethod,attr,omitempty"`
+	Sip            *Sip   `xml:"Sip,omitempty"`
+}

--- a/inboundxml/refer.go
+++ b/inboundxml/refer.go
@@ -4,6 +4,17 @@
 
 package inboundxml
 
+//Use the <Refer> element to transfer the caller back to the customer's in-house or legacy SIP infrastructure.
+//Through initiating the <Refer> verb, CPaaS instructs the caller SIP device to initiate a new call to the external system and replace the CPaaS leg with that new call.
+//Therefore, the support of "blind" call transfers in Avaya CPaaS. The <Refer> verb can be invoked on inbound or outbound SIP calls.
+
+//Refer verb attributes.
+//action: URL to fetch the set of instructions for further processing. It is executed when the transfer fails with a failure response or when the <Refer> verb is timed out.
+//method: Method used to request the action URL.
+//timeout: The number of seconds CPaaS should wait for <Refer> verb to conclude.
+//callbackUrl: URL where the status of the <Refer> can be sent. Note: This URL only receives parameters containing information about the call. The call does not execute XML given as a callbackUrl.
+//callbackMethod: Method used to request the callback URL. Default Value: POST. Allowed Value: POST or GET.
+
 type Refer struct {
 	Value          string `xml:",chardata"`
 	Action         string `xml:"action,attr,omitempty"`

--- a/inboundxml/refer_test.go
+++ b/inboundxml/refer_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Avaya Cloud Inc. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package inboundxml
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestReferElement(t *testing.T) {
+	Convey("Refer should pass", t, func() {
+
+		ixml, err := New(Response{Refer: &Refer{
+			Action:         "https://example.com/actionURL",
+			Method:         "POST",
+			Timeout:        180,
+			CallbackUrl:    "https://example.com/callbackURL",
+			CallbackMethod: "POST",
+			Sip: &Sip{
+				Password: "pass",
+				Value:    "username@example.com",
+				Username: "username",
+			},
+		}})
+		fmt.Println("XML :")
+		fmt.Println(ixml)
+		So(ixml, ShouldNotBeNil)
+		So(ixml.String(), ShouldEqual, "<Response><Refer action=\"https://example.com/actionURL\" method=\"POST\" timeout=\"180\" callbackUrl=\"https://example.com/callbackURL\" callbackMethod=\"POST\"><Sip username=\"username\" password=\"pass\">username@example.com</Sip></Refer></Response>")
+		So(err, ShouldBeNil)
+	})
+}

--- a/inboundxml/refer_test.go
+++ b/inboundxml/refer_test.go
@@ -5,7 +5,6 @@
 package inboundxml
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -26,8 +25,7 @@ func TestReferElement(t *testing.T) {
 				Username: "username",
 			},
 		}})
-		fmt.Println("XML :")
-		fmt.Println(ixml)
+
 		So(ixml, ShouldNotBeNil)
 		So(ixml.String(), ShouldEqual, "<Response><Refer action=\"https://example.com/actionURL\" method=\"POST\" timeout=\"180\" callbackUrl=\"https://example.com/callbackURL\" callbackMethod=\"POST\"><Sip username=\"username\" password=\"pass\">username@example.com</Sip></Refer></Response>")
 		So(err, ShouldBeNil)

--- a/inboundxml/response.go
+++ b/inboundxml/response.go
@@ -14,6 +14,7 @@ type Response struct {
 	Invalid           *Invalid           `xml:"Invalid,omitempty"`
 	PlayLastRecording *PlayLastRecording `xml:"PlayLastRecording,omitempty"`
 	Dial              *Dial              `xml:"Dial,omitempty"`
+	Refer             *Refer             `xml:"Refer,omitempty"`
 	Gather            *Gather            `xml:"Gather,omitempty"`
 	Hangup            *Hangup            `xml:"Hangup,omitempty"`
 	Pause             *Pause             `xml:"Pause,omitempty"`

--- a/inboundxml/schema/inboundxml.xsd
+++ b/inboundxml/schema/inboundxml.xsd
@@ -308,6 +308,18 @@
             <xsd:attribute name="outboundAction" type="booleans" use="optional"/>
         </xsd:complexType>
     </xsd:element>
+    <xsd:element name="Refer">
+        <xsd:complexType mixed="true">
+            <xsd:choice maxOccurs="unbounded" minOccurs="0">
+                <xsd:element ref="Sip"/>
+            </xsd:choice>
+            <xsd:attribute name="action" type="xsd:anyURI" use="optional"/>
+            <xsd:attribute name="method" type="http_methods" use="optional"/>
+            <xsd:attribute name="timeout" type="positive_integer" use="optional"/>
+            <xsd:attribute name="callbackUrl" type="xsd:anyURI" use="optional"/>
+            <xsd:attribute name="callbackMethod" type="http_methods" use="optional"/>
+        </xsd:complexType>
+    </xsd:element>
     <xsd:element name="Agent"/>
     <xsd:element name="Connect">
         <xsd:complexType mixed="true">
@@ -433,6 +445,7 @@
                 <xsd:element maxOccurs="unbounded" minOccurs="0" ref="Gather"/>
                 <xsd:element maxOccurs="unbounded" minOccurs="0" ref="Record"/>
                 <xsd:element maxOccurs="unbounded" minOccurs="0" ref="Dial"/>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" ref="Refer"/>
                 <xsd:element maxOccurs="unbounded" minOccurs="0" ref="Hangup"/>
                 <xsd:element maxOccurs="unbounded" minOccurs="0" ref="Redirect"/>
                 <xsd:element maxOccurs="unbounded" minOccurs="0" ref="Ping"/>


### PR DESCRIPTION
**JIRA:** ZANGCPAAS-5385

**Changes:**

- Added go module for dependency management and upgrade go version to 1.16.
- Support for Refer verb in GO SDK

Refer: https://docs.avayacloud.com/aspx/inboundxml#refer